### PR TITLE
correct overdrawing of logo in the Android app

### DIFF
--- a/android/app/src/main/res/drawable/launch_background.xml
+++ b/android/app/src/main/res/drawable/launch_background.xml
@@ -3,9 +3,9 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/background" />
 
-    <item>
+    <!--<item>
         <bitmap
             android:gravity="center"
             android:src="@drawable/ic_splash" />
-    </item>
+    </item> -->
 </layer-list>


### PR DESCRIPTION
We found out that there was an overdraw while doing a profiling of your app while using the debug GPU overdraw from the developer options.